### PR TITLE
Add per-user service

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,7 +13,7 @@ install="${pkgname}.install"
 source=("bittorrent-sync.install"
 	"btsync.service")
 sha256sums=('b2240a8356c24356ca83bc2f9dcf759ceaa7dcdbbec45f5cc8cd0928b8f89df5'
-	    '3ccf1a7e3f066bf4453035cbb5b4956b6d69d6abd4c41f34ed36b84f345ae90f')
+	    '4725df55f29378a2fd1b194364c5927977c96b4ce622906d0d7cf80ae9493a9d')
 
 if [ "$CARCH" == x86_64 ]; then
 	source+=("http://syncapp.bittorrent.com/$pkgver/btsync_x64-$pkgver.tar.gz")

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,9 +11,13 @@ license=('custom')
 backup=("etc/btsync.conf")
 install="${pkgname}.install"
 source=("bittorrent-sync.install"
-	"btsync.service")
-sha256sums=('b2240a8356c24356ca83bc2f9dcf759ceaa7dcdbbec45f5cc8cd0928b8f89df5'
-	    '4725df55f29378a2fd1b194364c5927977c96b4ce622906d0d7cf80ae9493a9d')
+	"btsync.service"
+	"btsync@.service"
+	)
+sha256sums=('0c642991865ab2f280ee00906ce50442dd13b62362637b53f88fa552e7f11a46'
+	    '4725df55f29378a2fd1b194364c5927977c96b4ce622906d0d7cf80ae9493a9d'
+	    'c0b637fb8d3f8b8a35a81683b3540b3155da1ceba83783a60723c832d1d4162e'
+	    )
 
 if [ "$CARCH" == x86_64 ]; then
 	source+=("http://syncapp.bittorrent.com/$pkgver/btsync_x64-$pkgver.tar.gz")
@@ -40,6 +44,8 @@ package() {
 	install -D -m 755 btsync "${pkgdir}/usr/bin/btsync"
 
 	install -D -m 644 btsync.service "${pkgdir}/usr/lib/systemd/system/btsync.service"
+	install -D -m 644 btsync@.service "${pkgdir}/usr/lib/systemd/system/btsync@.service"
 
 	install -D -m 644 LICENSE.TXT "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.TXT"
+
 }

--- a/bittorrent-sync.install
+++ b/bittorrent-sync.install
@@ -4,9 +4,41 @@ post_install() {
     fi
     mkdir -p /var/lib/btsync && chown -R btsync:btsync /var/lib/btsync
 
-    echo -e "Configuration is located at /etc/btsync.conf and contains sample data"
-    echo -e "The corresponding systemd-unit is 'btsync.service'"
-    echo -e "WebGUI can be accessed at http://localhost:8888"
+cat << EOF
+
+  Configuration is located at /etc/btsync.conf and contains sample data.
+  The corresponding systemd-unit is 'btsync.service'
+  WebGUI can be accessed at http://localhost:8888
+
+  User-specific BTSync configuration
+
+  Helps to set ownership to someone other than root for files that are copied
+  with btsync. Copy /etc/btsync.conf to ~/.config/btsync/btsync.conf for
+  the user you wish to configure btsync as:
+
+  mkdir -p ~/.config/btsync
+  cp /etc/btsync.conf ~/.config/btsync/btsync.conf
+
+  Replace user-specific references with the appropriate information,
+  particularly the following settings:
+
+  - webui.listen
+  - webui.login
+  - webui.password
+
+  The systemd script (/usr/lib/systemd/system/btsync@.service) assumes the
+  following two settings:
+  - storage_path: $HOME/.config/btsync
+  - pid_file: $HOME/.config/btsync/sync.pid (default, leave this commented out)
+
+  To start btsync, execute:
+
+  systemctl start btsync@user
+
+  where 'user' is your username.
+
+EOF
+
 }
 
 post_upgrade() {

--- a/btsync.service
+++ b/btsync.service
@@ -7,9 +7,8 @@ Type=forking
 User=btsync
 Group=btsync
 ExecStart=/usr/bin/btsync --config /etc/btsync.conf
-ExecStop=/usr/bin/killall btsync
-ExecReload=/usr/bin/killall btsync ; /usr/bin/btsync --config /etc/btsync.conf
 Restart=on-abort
+PIDFile=/var/lib/btsync/sync.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/btsync@.service
+++ b/btsync@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BitTorrent Sync service for %i
+After=network.target
+
+[Service]
+Type=forking
+User=%i
+ExecStart=/usr/bin/btsync --config %h/.config/btsync/btsync.conf
+Restart=on-abort
+PIDFile=%h/.config/btsync/sync.pid
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
With these changes, you can do

```
# systemctl start btsync@username
```

to run the service as user `username`. The service expects to find a config file at `~/.config/btsync/btsync.conf` and you can run this in parallel to the existing btsync.service.

The changes include some changes to btsync.service to allow stopping one of the services without stopping them all. The btsync executable provides a sync.pid in the storage directory, so by pointing systemd to use that, you can run the btsync service for multiple users in parallel, independently of each other.
